### PR TITLE
C標準関数やシステムコールをモック化できるよう、expect()とset_callback()を両方有効化した時の仕様を変更

### DIFF
--- a/PCUnit/pcunit_mock.rb
+++ b/PCUnit/pcunit_mock.rb
@@ -750,8 +750,32 @@ class MockGen
 				if fd.ret_type != "void"
 					f.puts "		#{local_ret} = #{local_expectation}->retval;"
 				end
+				f.puts "		if (#{@mock_basename}.#{fd.name}_funcptr) {"
+				if va_list_name != ''
+					f.puts "			va_list #{va_list_name};"
+				end
+				if va_list_name != ''
+					f.puts "			va_start(#{va_list_name}, #{prev_param_name});"
+				end
+				s = "			#{@mock_basename}.#{fd.name}_funcptr("
+				fd.params.each { |param|
+					if !param[1].empty?
+						s += param[1]
+						s += ", "
+					end
+				}
+				if va_list_name != ''
+					s += va_list_name
+				end
+				s.sub!(/, $/, '')
+				s += ");"
+				f.puts s
+				if va_list_name != ''
+					f.puts "			va_end(#{va_list_name});"
+				end
+				f.puts "		}"
 				f.puts "	}"
-				f.puts "	if (#{@mock_basename}.#{fd.name}_funcptr) {"
+				f.puts "	else if (#{@mock_basename}.#{fd.name}_funcptr) {"
 				if va_list_name != ''
 					f.puts "		va_list #{va_list_name};"
 				end


### PR DESCRIPTION
遅くなりましたがissues #4 の件、修正案を作成しましたのでpull requestさせていただきます
